### PR TITLE
Remove deprecations for PayPal and Braintree

### DIFF
--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::BraintreeGateway < Gateway
+  class Gateway::BraintreeGateway < PaymentMethod
     preference :environment, :string
     preference :merchant_id, :string
     preference :merchant_account_id, :string

--- a/app/models/spree/gateway/pay_pal_gateway.rb
+++ b/app/models/spree/gateway/pay_pal_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PayPalGateway < Gateway
+  class Gateway::PayPalGateway < PaymentMethod
     preference :login, :string
     preference :password, :string
     preference :signature, :string


### PR DESCRIPTION
This also removes deprecation messages for PayPal and Braintree gateways